### PR TITLE
Refactor inbox cleanup to load senders from external file

### DIFF
--- a/my-scripts/README.md
+++ b/my-scripts/README.md
@@ -108,6 +108,36 @@ Arguments:
 * --timeout SECS       Per-connection timeout (default: 10; must be > 0)
 * --verbose            Print progress information to stderr
 
+### cleanup_inbox.applescript
+Moves newsletter and commercial emails from iCloud INBOX and Exchange Indbakke
+to their respective Deleted folders. Sender addresses are loaded at runtime
+from `cleanup_senders.txt` in the same directory, so the list can be updated
+without editing the script.
+
+Run with:
+```
+osascript cleanup_inbox.applescript
+```
+
+### cleanup_senders.txt
+Plain-text list of sender addresses targeted by `cleanup_inbox.applescript`.
+One address per line. Blank lines and lines starting with `#` are ignored, so
+entries can be grouped with comments. Add or remove addresses here to change
+what gets cleaned up.
+
+### top_senders.applescript
+Scans iCloud INBOX and Exchange Indbakke and prints the top N senders ranked
+by message count. Useful for identifying candidates to add to
+`cleanup_senders.txt`.
+
+Change the `topN` variable at the top of the script to control how many
+senders are shown (default: 50).
+
+Run with:
+```
+osascript top_senders.applescript
+```
+
 ### starfield.py
 Animated terminal star field. Stars fade in and out through colour gradients
 using Unicode round and pointed glyphs. Colour depth (truecolor / 256-colour /

--- a/my-scripts/cleanup_inbox.applescript
+++ b/my-scripts/cleanup_inbox.applescript
@@ -2,54 +2,20 @@
 -- cleanup_inbox.applescript
 -- Moves newsletter/commercial emails from iCloud INBOX and Exchange Indbakke
 -- to their respective Deleted folders.
--- Senders targeted: LinkedIn (3 addresses) + commercial newsletters/ads
+-- Target senders are read from cleanup_senders.txt in the same directory.
 
-set targetSenders to { ¬
-	"messages-noreply@linkedin.com", ¬
-	"jobalerts-noreply@linkedin.com", ¬
-	"notifications-noreply@linkedin.com", ¬
-	"newsletter@backerclub.co", ¬
-	"hello@pen.store", ¬
-	"nyhedsmail@email.ilva.com", ¬
-	"kontakt@skousen.dk", ¬
-	"news@news.toejeksperten.dk", ¬
-	"newsletter@storybundle.com", ¬
-	"dsb@mail.dsb.dk", ¬
-	"familyclub@bones.dk", ¬
-	"eu@news.ugreen.com", ¬
-	"newsletter@update.just-eat.dk", ¬
-	"marketing@proshop.dk", ¬
-	"communications@stardockentertainment.info", ¬
-	"info@newsletter.tipster.dk", ¬
-	"elgiganten@email.elgiganten.dk", ¬
-	"jonas@email.sunset-boulevard.dk", ¬
-	"donotreply@audible.co.uk", ¬
-	"app@hej.lagkagehuset.dk", ¬
-	"contact@discoverscifi.com", ¬
-	"followups@clean.email", ¬
-	"mail@wagner.dk", ¬
-	"news@news.wagner.dk", ¬
-	"info.dk@sc.stenaline.com", ¬
-	"monday.reply@brighttalk.com", ¬
-	"noreply_at_glassdoor_com_zypwtjpq67_8a4c403d@privaterelay.appleid.com", ¬
-	"fly_at_seaplanes_dk_ntk24arfj4504v_2b7x5967@icloud.com", ¬
-	"mail@send.originaltalks.dk", ¬
-	"media@fjordtours.dk", ¬
-	"email.campaign@sg.booking.com", ¬
-	"synology@news.synology.com", ¬
-	"info@members.netflix.com", ¬
-	"DoNotReply@ConnectedCommunity.org", ¬
-	"sarahlindseycooke+killer-tater-tots@substack.com", ¬
-	"aeg@marketing.aeg.com", ¬
-	"notepad@theverge.com", ¬
-	"kontakt@unsolved.se", ¬
-	"subscriptions@theverge.com", ¬
-	"groups-noreply@linkedin.com", ¬
-	"noreply@bones.dk", ¬
-	"hola@info.hotelsviva.com", ¬
-	"DoNotReply@mcdonalds.com", ¬
-	"prosa@info.prosa.dk", ¬
-	"no-reply@order.just-eat.dk"}
+-- Load sender list from cleanup_senders.txt (same directory as this script)
+set scriptDir to do shell script "dirname " & quoted form of POSIX path of (path to me)
+set senderFilePath to scriptDir & "/cleanup_senders.txt"
+set rawLines to paragraphs of (do shell script "cat " & quoted form of senderFilePath)
+
+set targetSenders to {}
+repeat with ln in rawLines
+	set trimmed to ln as string
+	if trimmed is not "" and trimmed does not start with "#" then
+		set end of targetSenders to trimmed
+	end if
+end repeat
 
 set movedCount to 0
 set skippedCount to 0

--- a/my-scripts/cleanup_senders.txt
+++ b/my-scripts/cleanup_senders.txt
@@ -1,0 +1,62 @@
+# cleanup_senders.txt
+# One sender address per line. Blank lines and lines starting with # are ignored.
+# Used by cleanup_inbox.applescript to decide which emails to move to Deleted.
+
+# LinkedIn
+messages-noreply@linkedin.com
+jobalerts-noreply@linkedin.com
+notifications-noreply@linkedin.com
+groups-noreply@linkedin.com
+
+# Retail / commercial newsletters
+hello@pen.store
+nyhedsmail@email.ilva.com
+kontakt@skousen.dk
+news@news.toejeksperten.dk
+elgiganten@email.elgiganten.dk
+marketing@proshop.dk
+mail@wagner.dk
+news@news.wagner.dk
+aeg@marketing.aeg.com
+DoNotReply@mcdonalds.com
+
+# Food & dining
+jonas@email.sunset-boulevard.dk
+app@hej.lagkagehuset.dk
+newsletter@update.just-eat.dk
+no-reply@order.just-eat.dk
+familyclub@bones.dk
+noreply@bones.dk
+
+# Travel
+info.dk@sc.stenaline.com
+media@fjordtours.dk
+hola@info.hotelsviva.com
+email.campaign@sg.booking.com
+fly_at_seaplanes_dk_ntk24arfj4504v_2b7x5967@icloud.com
+
+# Tech / software
+eu@news.ugreen.com
+synology@news.synology.com
+communications@stardockentertainment.info
+DoNotReply@ConnectedCommunity.org
+
+# Media / entertainment
+newsletter@backerclub.co
+newsletter@storybundle.com
+contact@discoverscifi.com
+sarahlindseycooke+killer-tater-tots@substack.com
+notepad@theverge.com
+subscriptions@theverge.com
+kontakt@unsolved.se
+donotreply@audible.co.uk
+info@members.netflix.com
+
+# Other
+dsb@mail.dsb.dk
+info@newsletter.tipster.dk
+prosa@info.prosa.dk
+monday.reply@brighttalk.com
+followups@clean.email
+mail@send.originaltalks.dk
+noreply_at_glassdoor_com_zypwtjpq67_8a4c403d@privaterelay.appleid.com


### PR DESCRIPTION
## Summary
- Moves hardcoded sender list out of `cleanup_inbox.applescript` into `cleanup_senders.txt`
- Senders can now be added/removed without editing the script
- Adds README docs for `cleanup_inbox.applescript`, `cleanup_senders.txt`, and `top_senders.applescript`

## Test plan
- [ ] Run `osascript cleanup_inbox.applescript` and confirm it reads from `cleanup_senders.txt`
- [ ] Add/remove an address from `cleanup_senders.txt` and verify behavior changes accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)